### PR TITLE
Add multiple put events

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ Start off by creating an Amazon Mobile Analytics event reporter:
 
 # THE AMAZON MOBILE ANALYTICS EVENT URL
 # NOTE: MAYBE SET IT IN AN ENVIRONMENT VARIABLE AS WELL
-aws_mobile_anlaytics_url = 'https://mobileanalytics.us-east-1.amazonaws.com/2014-06-05/events' 
+aws_mobile_anlaytics_url = 'https://mobileanalytics.us-east-1.amazonaws.com/2014-06-05/events'
 
 # YOUR AMAZON MOBILE ANALYTICS APP ID
 aws_mobile_analytics_app_id = ENV['AWS_MOBILE_ANALYTICS_APP_ID']
 
 # YOUR AMAZON MOBILE ANALYTICS COGNITO POOL
-aws_mobile_analytics_identity_pool = ENV['AWS_MOBILE_ANALYTICS_IDENTITY_POOL_ID'] 
+aws_mobile_analytics_identity_pool = ENV['AWS_MOBILE_ANALYTICS_IDENTITY_POOL_ID']
 
-reporter =  AwsmaRails::Reporter.new(aws_mobile_anlaytics_url, 
-                                     aws_mobile_analytics_app_id, 
+reporter =  AwsmaRails::Reporter.new(aws_mobile_anlaytics_url,
+                                     aws_mobile_analytics_app_id,
                                      aws_mobile_analytics_identity_pool)
 ```
 
@@ -45,28 +45,39 @@ You can then you the create `reporter` object to send event to Amazon Mobile Ana
 ```ruby
 
 # YOUR USER'S ID
-client_id = .. 
- 
+client_id = ..
+
  # YOUR USERS SESSION ID OR USE 'no-session' IF THE EVENT IS NOT DIRECTLY RELATED TO ANY SESSION (FOR EXAMPLE: A PUSH NOTIFICATION)
-session_id = .. 
+session_id = ..
 
 # YOUR APP TITLE
-app_title = .. 
+app_title = ..
 
 # YOUR APP PACKAGE NAME, USUALLY IN THE FOLLOWING FORMAT: com.your.brand.name
-app_package_name = .. 
+app_package_name = ..
 
 # THE EVENT NAME
-event_name = .. 
+event_name = ..
 
 # A HASH THAT CONTAINS THE EVENT ATTRIBUTES
-attributes = .. 
+attributes = ..
 
 # A HASH THAT CONTAINS THE EVENT METRICS
-metrics = .. 
+metrics = ..
 
-reporter.report_event(client_id, session_id, app_title, 
+# REPORT SINGLE EVENT
+reporter.report_event(client_id, session_id, app_title,
                       app_package_name, event_name, attributes, metrics)
+
+# REPORT MULTIPLE EVENTS
+events = [{
+  'event_name' => event_name,
+  'session_id' => session_id,
+  'attributes' => attributes,
+  'metrics'    => metrics
+}, ...]
+
+reporter.report_events(client_id, app_title, app_package_name, events)
 ```
 
 ## License

--- a/awsma_rails.gemspec
+++ b/awsma_rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'rails', '~> 4.2.4'
+  s.add_dependency 'rails', '>= 3.2.22.5'
 
   s.add_development_dependency 'sqlite3'
 end

--- a/lib/awsma_rails/aws_post_request.rb
+++ b/lib/awsma_rails/aws_post_request.rb
@@ -1,3 +1,5 @@
+require 'net/http'
+
 module AwsmaRails
   class AwsPostRequest
     def initialize(endpoint_url, body, user_agent, custom_aws_target = nil, custom_aws_client_context = nil)

--- a/lib/awsma_rails/reporter.rb
+++ b/lib/awsma_rails/reporter.rb
@@ -24,8 +24,23 @@ module AwsmaRails
     # @param  [Hash]    metrics     The custom events metrics (optional)
     # @return [Net::HTTP] response of analytics report (response code should be 202 if successful)
     def report_event(client_id, session_id, app_title, app_package_name, event_name, attributes = {}, metrics = {})
+      events = [{
+                    'event_name' => event_name,
+                    'session_id' => session_id,
+                    'attributes' => attributes,
+                    'metrics' => metrics
+                }]
+
+      self.report_events(client_id, app_title, app_package_name, events)
+    end
+
+    # @param  [String]  client_id   The users mobile analytics client id
+    # @param  [String]  app_title   The app title (ex: Fun Game)
+    # @param  [String]  app_package_name  The app package name (ex: com.example.fungame)
+    # @return [Net::HTTP] response of analytics report (response code should be 202 if successful)
+    def report_events(client_id, app_title, app_package_name, events = [{'event_name' => '', 'session_id' => '', 'attributes' => {}, 'metrics' => {}}])
       awsma_request = AwsmaPostRequest.new(@awsma_endpoint_url,
-                                           create_analytics_data(event_name, session_id, attributes, metrics),
+                                           create_analytics_batch_data(events),
                                            @user_agent,
                                            create_client_context(client_id, app_title, app_package_name),
                                            @cognito_credentials)
@@ -43,40 +58,48 @@ module AwsmaRails
 
     private
 
-    def create_analytics_data(event_name, session_id, attributes, metrics)
-      timestamp = Time.now.utc.iso8601
+    def create_analytics_data(events)
+      request_events = []
+      events.inject(request_events) do |request_events, event|
+        event = event.symbolize_keys
+        timestamp = Time.now.utc.iso8601
 
-      aws_analytics_data = {'events' => [{
-                                             'eventType' => event_name,
-                                             'timestamp' => timestamp,
-                                             'version' => 'v2.0',
-                                             'session' => {'id' => session_id,
-                                                           'startTimestamp' => timestamp},
-                                             'attributes' => attributes,
-                                             'metrics' => metrics
-                                         }]}
+        request_events << {
+          'eventType' => event[:event_name],
+          'timestamp' => timestamp,
+          'version' => 'v2.0',
+          'session' => {
+              'id' => event[:session_id],
+              'startTimestamp' => timestamp
+          },
+          'attributes' => event[:attributes],
+          'metrics' => event[:metrics]
+        }
+      end
+
+      aws_analytics_data = { 'events' => request_events}
 
       aws_analytics_data.to_json
     end
 
     def create_client_context(client_id, app_title, app_package_name)
       aws_client_context = {
-          'client' => {
-              'client_id' => client_id,
-              'app_title' => app_title,
-              'app_package_name' => app_package_name
-          },
-          'env' => {
-              'platform' => 'linux',
-              'model' => 'SERVER'
-          },
-          'services' => {
-              'mobile_analytics' => {
-                  'app_id' => @app_id,
-                  'sdk_name' => 'awsma_rails',
-                  'sdk_version' => AwsmaRails::VERSION
-              }
+        'client' => {
+          'client_id' => client_id,
+          'app_title' => app_title,
+          'app_package_name' => app_package_name
+        },
+        'env' => {
+          'platform' => 'linux',
+          'model' => 'SERVER'
+        },
+        'services' => {
+          'mobile_analytics' => {
+            'app_id' => @app_id,
+            'sdk_name' => 'awsma_rails',
+            'sdk_version' => AwsmaRails::VERSION
           }
+        }
       }
 
       aws_client_context.to_json

--- a/lib/awsma_rails/version.rb
+++ b/lib/awsma_rails/version.rb
@@ -1,3 +1,3 @@
 module AwsmaRails
-  VERSION = '0.1.8'
+  VERSION = '0.1.9'
 end


### PR DESCRIPTION
AWS Mobile Analytics REST API has the ability to receive multiple events using a single request. By using multiple put events, the app could save time and resources.

Changes:
1. Added ability to send multiple events
2. Changed rails dependency to >= 3.2.22.5
3. Require net/http in AwsPostRequest
4. Change version from 0.1.8 to 0.1.9
5. Updated README.md
